### PR TITLE
Fixed issue #6.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import find_packages
 from distutils.core import setup
 
 package_name = "dbt-mssql"
-package_version = "1.0.3"
+package_version = "1.0.4"
 description = """The mssql adpter plugin for dbt (data build tool)"""
 
 setup(
@@ -19,6 +19,7 @@ setup(
         'dbt': [
             'include/mssql/dbt_project.yml',
             'include/mssql/macros/*.sql',
+            'include/mssql/macros/materializations/**/*.sql',
         ]
     },
     install_requires=[


### PR DESCRIPTION
This issue was caused by the `package_data` variable being setup incorrectly in `setup.py`. Apparently the file listing is **not** recursive, which caused the `sdist` files to lack several macro overrides needed to function.